### PR TITLE
Enforce https

### DIFF
--- a/configurationOptions.md
+++ b/configurationOptions.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-03-23"
+lastupdated: "2017-07-13"
 
 ---
 

--- a/configurationOptions.md
+++ b/configurationOptions.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-13"
+lastupdated: "2017-07-18"
 
 ---
 

--- a/enforceHTTPS.md
+++ b/enforceHTTPS.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-17"
+lastupdated: "2017-07-18"
 
 ---
 

--- a/enforceHTTPS.md
+++ b/enforceHTTPS.md
@@ -1,0 +1,32 @@
+---
+
+copyright:
+  years: 2015, 2017
+lastupdated: "2017-07-17"
+
+---
+
+{:shortdesc: .shortdesc}
+{:new_window: target="_blank"}
+{:codeblock: .codeblock}
+
+# Enforce HTTPS on all pages in your application
+{: #enforce_https}
+
+When you run your application in Bluemix with the express framework, the following changes need to be made to enforce HTTPS instead of HTTP on all pages in your application.
+
+```
+var express = require("express");
+var app = express();
+
+app.enable('trust proxy');
+
+app.use (function (req, res, next) {
+  if (req.secure || process.env.BLUEMIX_REGION === undefined) {
+    next();
+  } else {
+    console.log('redirecting to https');
+    res.redirect('https://' + req.headers.host + req.url);
+  }
+});
+```

--- a/toc
+++ b/toc
@@ -1,7 +1,7 @@
 {:navgroup: .navgroup}
 {:topicgroup: .topicgroup}
 
-{: .toc subcollection="Nodejs" audience="runtime"}
+{: .toc subcollection="Nodejs" audience="runtime" href="/docs/runtimes/nodejs/getting-started.html"}
 SDK for Node.js
 
     {: .navgroup id="learn"}
@@ -12,6 +12,7 @@ SDK for Node.js
     {: .navgroup id="howto"}
     startup.md
     runningLocally.md
+    enforceHTTPS.md
 
     {: .topicgroup}
     Work offline or with a proxy


### PR DESCRIPTION
Added enforce HTTPS page and TOC changes.

Staging: https://console.stage1.bluemix.net/docs/runtimes/nodejs/enforceHTTPS.html#enforce_https
