### PR TITLE
Port 3000 clarification

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2017
-lastupdated: "2017-09-06"
+lastupdated: "2017-09-22"
 
 ---
 
@@ -105,7 +105,7 @@ cf api <API-endpoint>
    | US South       |https://api.ng.bluemix.net     |
    | United Kingdom | https://api.eu-gb.bluemix.net  |
    | Sydney         | https://api.au-syd.bluemix.net |
-   | Frankfurt     | https://api.eu-de.bluemix.net | 
+   | Frankfurt     | https://api.eu-de.bluemix.net |
 
 Log in to your {{site.data.keyword.Bluemix_notm}} account.
 
@@ -176,6 +176,8 @@ npm start
   {: pre}
 
   View your local app at http://localhost:3000. Any names you enter into the app will now get added to the database.
+
+** Avoid trouble**: Bluemix defines the PORT environment variable when your app runs on the cloud. When you run your app locally, the PORT variable is not defined, so 3000 is used as the port number. See [Run your app locally](runningLocally.html#hints) for more information.
 
   Your local app and the {{site.data.keyword.Bluemix_notm}} app are sharing the database. Names you add from either app will appear in both when you refresh the browsers.
 

--- a/runningLocally.md
+++ b/runningLocally.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-05-30"
+lastupdated: "2017-09-22"
 
 ---
 
@@ -14,13 +14,14 @@ lastupdated: "2017-05-30"
 # Run the Node.js application locally
 {: #hints}
 
-Use this information to facilitate running your Node.js application both locally and on {{site.data.keyword.Bluemix}}.
+Set a port number to run your Node.js application locally without causing conflicts when you run it on {{site.data.keyword.Bluemix}}.
 {: shortdesc}
 
-The following example shows part of the source for an **js** file:
+When the application is running on Bluemix, the PORT environment variable is allocated by Cloud Foundry. However, when the application is running locally, PORT is not defined, so you can define the port for your application. To avoid conflicts, define the port that your app listens to locally something different than the port used by Bluemix.
+
+In the following example for a **js** file, **3000** is used as the port number. By using **3000**, you can run the application locally for testing purposes and on Bluemix without making changes.
+
 ```
 var port = (process.env.PORT || 3000);
 ```
 {: codeblock}
-
-With this code, when the application is running on Bluemix, the PORT environment variable contains the port value that is internal to Bluemix, and on which the app listens for incoming connections. When the application is running locally, PORT is not defined so **3000** is used as the port number. Written this way, you can run the application locally for testing purposes and on Bluemix without making further changes.


### PR DESCRIPTION
View on [staging getting started](https://console.stage1.bluemix.net/docs/runtimes/nodejs/getting-started.html#getting-started-tutorial) and [staging running locally](https://console.stage1.bluemix.net/docs/runtimes/nodejs/runningLocally.html#hints)

https://github.ibm.com/was-buildpacks/bluemix-runtimes-issues/issues/66